### PR TITLE
Hide cursor only if JavaScript is enabled

### DIFF
--- a/components/CustomCursor.vue
+++ b/components/CustomCursor.vue
@@ -72,7 +72,7 @@ watch(() => route.path, () => {
 
 onMounted(() => {
   setupEventListeners()
-  document.body.style.cursor = 'none'
+  document.body.classList.add('cursor-custom')
 })
 
 onUnmounted(() => {
@@ -80,7 +80,7 @@ onUnmounted(() => {
     cancelAnimationFrame(rafId)
   }
   removeEventListeners()
-  document.body.style.cursor = 'auto'
+  document.body.classList.remove('cursor-custom')
 })
 </script>
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-black/95 text-white font-mono flex flex-col cursor-custom">
+  <div class="min-h-screen bg-black/95 text-white font-mono flex flex-col">
     <nav class="fixed top-0 w-full bg-black/90 backdrop-blur-sm border border-green-500/20 z-50">
       <div class="max-w-4xl mx-auto px-2 md:px-4">
         <div class="flex items-center justify-center h-10 md:h-12">


### PR DESCRIPTION
This pull request removes the "cursor-custom" class from the default layout. Instead, it makes the CustomCursor component add this class to the body when it is mounted. This ensures that the real cursor is hidden only when JavaScript is enabled. This pull request resolves #2.